### PR TITLE
Try incremental ports if configured port already bound.

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -249,6 +249,37 @@ define([
 				new Array(512).join('.') + ' -->');
 		},
 
+		_listen: function(server) {
+			const args = Array.from(arguments);
+			const lastArgIndex = arguments.length - 1;
+			let port = args[1];
+			if (typeof args[lastArgIndex] === 'function') {
+				const callback = args[lastArgIndex];
+
+				args[lastArgIndex] = function() {
+					callback(port);
+				}
+			}
+
+			const config = this.config;
+			if(typeof config.maxPort === 'undefined') {
+				config.maxPort = Math.min(config.port + 100, 65535);
+			}
+			const serverInstance = server.listen.apply(server, args.slice(1))
+				.on('error', function(err) {
+					if(err.errno === 'EADDRINUSE') {
+						if (config.maxPort < port + 1) {
+							throw err;
+						}
+						port++;
+						serverInstance.listen.apply(serverInstance, [port].concat(args.slice(2, lastArgIndex)));
+					} else {
+						throw err;
+					}
+				});
+			return serverInstance;
+		},
+
 		start: function () {
 			return new Promise(function (resolve) {
 				var server = this.server = http.createServer(lang.bind(this, '_handler'));
@@ -278,7 +309,7 @@ define([
 					});
 				});
 
-				server.listen(this.config.port, resolve);
+				this._listen(server, this.config.port, resolve);
 			}.bind(this));
 		},
 

--- a/lib/executors/Runner.js
+++ b/lib/executors/Runner.js
@@ -109,8 +109,9 @@ define([
 
 			function createAndStartProxy() {
 				var proxy = self._createProxy(config);
-				return proxy.start().then(function () {
+				return proxy.start().then(function (port) {
 					self.proxy = proxy;
+					self._updateConfig(port);
 					return self.reporterManager.emit('proxyStart', proxy);
 				});
 			}
@@ -270,7 +271,8 @@ define([
 				excludeInstrumentation: config.excludeInstrumentation,
 				instrument: true,
 				waitForRunner: config.runnerClientReporter.waitForRunner,
-				port: config.proxyPort
+				port: config.proxyPort,
+				maxPort: config.proxyMaxPort
 			});
 		},
 
@@ -297,6 +299,21 @@ define([
 			}
 
 			config.tunnelOptions.servers = (config.tunnelOptions.servers || []).concat(config.proxyUrl);
+		},
+
+		_updateConfig: function(port) {
+			const config = this.config;
+
+			const oldProxyPort = config.proxyPort;
+			config.proxyPort = port;
+
+			// replace old port with bound port
+			config.proxyUrl = config.proxyUrl.replace(':' + oldProxyPort, ':' + port);
+			
+			const lastIdx = config.tunnelOptions.servers.length - 1;
+			if (lastIdx >= 0) {
+				config.tunnelOptions.servers[lastIdx] = config.proxyUrl;
+			}
 		},
 
 		/**

--- a/tests/selftest.intern.js
+++ b/tests/selftest.intern.js
@@ -1,5 +1,6 @@
 define({
 	proxyPort: 9000,
+	proxyMaxPort: 9003,
 	proxyUrl: 'http://localhost:9000/',
 
 	capabilities: {

--- a/tests/selftest.intern.js
+++ b/tests/selftest.intern.js
@@ -7,18 +7,15 @@ define({
 		'idle-timeout': 60
 	},
 	environments: [
-		{ browserName: 'internet explorer', version: '11.0', platform: 'WINDOWS', fixSessionCapabilities: false },
-		{ browserName: 'internet explorer', version: '10.0', platform: 'WIN8', fixSessionCapabilities: false },
-		{ browserName: 'internet explorer', version: '9.0', platform: 'WINDOWS', fixSessionCapabilities: false },
-		{ browserName: 'firefox', version: [ '33', '49' ], platform: [ 'WINDOWS', 'MAC' ],
+		{ browserName: 'chrome', version: [ '90' ], platform: [ 'LINUX' ],
 			fixSessionCapabilities: false },
-		{ browserName: 'chrome', version: [ '38', '52' ], platform: [ 'WINDOWS', 'MAC' ],
-			fixSessionCapabilities: false },
-		{ browserName: 'safari', version: [ '9', '10' ], fixSessionCapabilities: false }
 	],
 
 	maxConcurrency: 2,
-	tunnel: 'BrowserStackTunnel',
+	tunnel: 'SeleniumTunnel',
+	tunnelOptions: {
+		drivers: [ 'chrome' ]
+	},
 
 	loaderOptions: {
 		// Packages that should be registered with the loader in each testing environment


### PR DESCRIPTION
Just using a statically configured port is not good enough in some scenarios, e.g. when trying to run multiple intern instances on the same machine.
This PR makes intern try incremental port numbers up to a configured limit in an attempt to discover an unbound port.